### PR TITLE
Fix for #17: cast directory names to strings when creating the structure in memory

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStream.php
+++ b/src/main/php/org/bovigo/vfs/vfsStream.php
@@ -172,6 +172,7 @@ class vfsStream
     protected static function addStructure(vfsStreamDirectory $baseDir, array $structure)
     {
         foreach ($structure as $name => $data) {
+            $name = (string) $name;
             if (is_array($data) === true) {
                 self::addStructure(self::newDirectory($name)->at($baseDir), $data);
             } elseif (is_string($data) === true) {

--- a/src/test/php/org/bovigo/vfs/vfsStreamTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamTestCase.php
@@ -330,6 +330,21 @@ class vfsStreamTestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+    * @test
+    * @group issue_17
+    */
+    public function createCastsNumericDirectoriesToStrings()
+    {
+        $root = vfsStream::create(array('2011' => array ('test.txt' => 'some content')));
+        $this->assertTrue($root->hasChild('2011'));
+
+        $directory = $root->getChild('2011');
+        $this->assertVfsFile($directory->getChild('test.txt'), 'some content');
+
+        $this->assertTrue(file_exists('vfs://2011/test.txt'));
+    }
+
+    /**
      * helper function for assertions on vfsStreamFile
      *
      * @param  vfsStreamFile  $file


### PR DESCRIPTION
- Fixes #17: Cast the directory names to strings to work around PHP implicitely turning numeric array keys into integers even when you explicitly provided them as strings.
