### PR TITLE
Explicitly test separator when checking nested paths - fixes #24

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
@@ -126,7 +126,8 @@ abstract class vfsStreamAbstractContent implements vfsStreamContent
             return true;
         }
 
-        return (substr($name, 0, strlen($this->name)) === $this->name && strpos($name, '/') !== false);
+        $segment_name = $this->name.'/';
+        return (strncmp($segment_name, $name, strlen($segment_name)) == 0);
     }
 
     /**

--- a/src/test/php/org/bovigo/vfs/vfsStreamDirectoryTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamDirectoryTestCase.php
@@ -244,6 +244,40 @@ class vfsStreamDirectoryTestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * When testing for a nested path, verify that directory separators are respected properly
+     * so that subdir1/subdir2 is not considered equal to subdir1Xsubdir2.
+     *
+     * @test
+     * @group bug_24
+     * @group regression
+     */
+    public function explicitTestForSeparatorWithNestedPaths_Bug_24()
+    {
+        $mockChild = $this->getMock('vfsStreamContent');
+        $mockChild->expects($this->any())
+                  ->method('getType')
+                  ->will($this->returnValue(vfsStreamContent::TYPE_FILE));
+        $mockChild->expects($this->any())
+                  ->method('getName')
+                  ->will($this->returnValue('bar'));
+        
+        $subdir1 = new vfsStreamDirectory('subdir1');
+        $this->dir->addChild($subdir1);
+        
+        $subdir2 = new vfsStreamDirectory('subdir2');
+        $subdir1->addChild($subdir2);
+        
+        $subdir2->addChild($mockChild);
+        
+        $this->assertTrue($this->dir->hasChild('subdir1'), "Level 1 path with separator exists");
+        $this->assertTrue($this->dir->hasChild('subdir1/subdir2'), "Level 2 path with separator exists");
+        $this->assertTrue($this->dir->hasChild('subdir1/subdir2/bar'), "Level 3 path with separator exists");
+        $this->assertFalse($this->dir->hasChild('subdir1.subdir2'), "Path with period does not exist");
+        $this->assertFalse($this->dir->hasChild('subdir1.subdir2/bar'), "Nested path with period does not exist");
+    }
+    
+
+    /**
      * setting and retrieving permissions for a directory
      *
      * @test


### PR DESCRIPTION
Currently vfsStreamDirectory::hasChild() and getChild() can give false positives in certain circumstances with nested paths.

The issue is that multi-level paths are not properly compared in vfsStreamAbstractContent.php so that characters within a directory name can be treated as though they were a directory separator.

For eg:

``` php
$root = vfsStream::setup('root');
$path = vfsStream::url('root/subdir1/subdir2/foo');
mkdir($path, '0700',true);

// This is true:
echo $root->hasChild('subdir1/subdir2/foo');

// But so is this:
echo $root->hasChild('subdir1.subdir2/foo');

// And this:
echo $root->hasChild('subdir1Xsubdir2/foo');
```

I only noticed this because I changed my folder naming strategy to move from `www/foo/bar/com/page/path/data.html` to be `www.foo.bar.com/page/path/data.html` and tests that should have failed still passed!
