### PR TITLE
Set permissions properly when using vfsStream::copyFromFileSystem

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStream.php
+++ b/src/main/php/org/bovigo/vfs/vfsStream.php
@@ -259,14 +259,14 @@ class vfsStream
                 }
 
                 self::newFile($fileinfo->getFilename(),
-                              substr(sprintf('%o', $fileinfo->getPerms()), -4)
+                              octdec(substr(sprintf('%o', $fileinfo->getPerms()), -4))
                       )
                     ->withContent($content)
                     ->at($baseDir);
             } elseif ($fileinfo->isDir() === true && $fileinfo->isDot() === false) {
                 self::copyFromFileSystem($fileinfo->getPathname(),
                                          self::newDirectory($fileinfo->getFilename(),
-                                                            substr(sprintf('%o', $fileinfo->getPerms()), -4)
+                                                            octdec(substr(sprintf('%o', $fileinfo->getPerms()), -4))
                                                )
                                              ->at($baseDir),
                                          $maxFileSize


### PR DESCRIPTION
When copyFromFileSystem creates files and directories, it sets the permissions with the octal string, which completely breaks permissions, as no other code seems to do the conversion to integer for it.

This patch applies oct2dec to set the correct permissions.
