### PR TITLE
Fixed a possible bug regarding checking if a root directory exists

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -160,7 +160,8 @@ class vfsStreamWrapper
             return null;
         }
 
-        if (self::$root->getName() === $path) {
+        $name = self::$root->getName();
+        if ($name === $path || '/' . $name === $path) {
             return self::$root;
         }
 

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperDirTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperDirTestCase.php
@@ -613,5 +613,21 @@ class vfsStreamWrapperMkDirTestCase extends vfsStreamWrapperBaseTestCase
         $this->assertTrue($root->hasChild('testFolder'));
         $this->assertNotNull($root->getChild('testFolder'));
     }
+
+    /**
+     * is_dir() should return true after a root directory has been made using mkdir()
+     *
+     * @test
+     */
+    public function isDirShouldBeAbleToCheckForExistenceOfRootDir()
+    {
+        vfsStreamWrapper::register();
+
+        $url = vfsStream::url('/foobar');
+
+        $this->assertFalse(is_dir($url), "Directory '$url' should not exist");
+        $this->assertTrue(mkdir($url), "Directory '$url' should have been created");
+        $this->assertTrue(is_dir($url), "Directory '$url' should exist");
+    }
 }
 ?>


### PR DESCRIPTION
The following snippet seems to me a bit weird:

``` php
<?php
vfsStreamWrapper::register();

var_dump(mkdir('vfs:///foobar')); // true
var_dump(is_dir('vfs:///foobar')); // false
var_dump(is_dir('vfs://foobar')); // true
```

This PR fixes this issue (as in making the first call to `is_dir` above return `true`), and does not break any existing tests.

There might be a possibility that I'm misunderstanding something, so if you feel the above code looks correct, disregard this PR. :)
