### PR TITLE
Optimize autoload prefix in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "psr-0": { "org\\bovigo\\vfs": "src/main/php" }
+        "psr-0": { "org\\bovigo\\vfs\\": "src/main/php" }
     }
 }


### PR DESCRIPTION
By having more specific autoload prefixes it is possible to reduce the number of stat calls made. Also it prevents possible collisions.

Ref: https://github.com/zendframework/zf2/commit/e58c6cdbf50dd06b71e76a413fb870c95ab22bf5
