### PR TITLE
Added root filesystem test (failing).

### DIFF
--- a/src/test/php/org/bovigo/vfs/vfsStreamRootFilesystemTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamRootFilesystemTestCase.php
@@ -1,0 +1,17 @@
+<?php
+namespace org\bovigo\vfs;
+
+class vfsStreamRootFilesystemTestCase extends \PHPUnit_Framework_TestCase {
+    protected function setUp() {
+        vfsStream::setup('/');
+    }
+
+    public function testRootFilesystemRoundTrip() {
+        $file = vfsStream::url('foo');
+        $contents = 'bar';
+
+        file_put_contents($file, $contents);
+
+        $this->assertSame($contents, file_get_contents($file));
+    }
+}


### PR DESCRIPTION
I propose being able to store files directly into the vfs without first having to create an arbitrarily named directory to store everything in since I believe that is counter-intuitive for new users. I propose doing this by calling `vfsStream::setup('/');`, or better still, make it the default behaviour when calling `vfsStream::setup();`.

The test I have attached currently fails with the following error:

> file_put_contents(vfs://foo): failed to open stream: "org\bovigo\vfs\vfsStreamWrapper::stream_open" call failed

Please make it work :)
