### PR TITLE
[TASK] skip tests using stream_lock when running on hhvm

### DIFF
--- a/src/test/php/org/bovigo/vfs/vfsStreamExLockTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamExLockTestCase.php
@@ -35,6 +35,10 @@ class vfsStreamExLockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function filePutContentsLockShouldReportError()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in hhvm.');
+        }
         @file_put_contents(vfsStream::url('root/testfile'), "some string\n", LOCK_EX);
         $php_error = error_get_last();
         $this->assertEquals("file_put_contents(): Exclusive locks may only be set for regular files", $php_error['message']);

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperFlockTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperFlockTestCase.php
@@ -114,6 +114,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canRemoveLock()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $file->lock($fp, LOCK_EX);
@@ -149,6 +153,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canRemoveSharedLockWithoutRemovingSharedLockOnOtherFileHandler()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp1   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $fp2   = fopen(vfsStream::url('root/foo.txt'), 'rb');
@@ -205,6 +213,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canRemoveLockWithNonBlockingFlockCall()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $file->lock($fp, LOCK_EX);
@@ -222,6 +234,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canNotAquireExclusiveLockIfAlreadyExclusivelyLockedOnOtherFileHandler()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp1   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $fp2   = fopen(vfsStream::url('root/foo.txt'), 'rb');
@@ -243,6 +259,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canAquireExclusiveLockIfAlreadySelfExclusivelyLocked()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $file->lock($fp, LOCK_EX);
@@ -260,6 +280,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canNotAquireExclusiveLockIfAlreadySharedLockedOnOtherFileHandler()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp1   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $fp2   = fopen(vfsStream::url('root/foo.txt'), 'rb');
@@ -279,6 +303,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canAquireExclusiveLockIfAlreadySelfSharedLocked()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $file->lock($fp, LOCK_SH);
@@ -315,6 +343,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canAquireSharedLockIfAlreadySelfExclusivelyLocked()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $file->lock($fp, LOCK_EX);
@@ -349,6 +381,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canAquireSharedLockIfAlreadySharedLockedOnOtherFileHandler()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp1   = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $fp2   = fopen(vfsStream::url('root/foo.txt'), 'rb');
@@ -372,6 +408,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function removesExclusiveLockOnStreamClose()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $file->lock($fp, LOCK_EX);
@@ -390,6 +430,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function removesSharedLockOnStreamClose()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $file->lock($fp, LOCK_SH);
@@ -406,6 +450,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function notRemovesExclusiveLockOnStreamCloseIfExclusiveLockAcquiredOnOtherFileHandler()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp1 = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $fp2 = fopen(vfsStream::url('root/foo.txt'), 'rb');
@@ -425,6 +473,10 @@ class vfsStreamWrapperFlockTestCase extends \PHPUnit_Framework_TestCase
      */
     public function notRemovesSharedLockOnStreamCloseIfSharedLockAcquiredOnOtherFileHandler()
     {
+        // http://docs.hhvm.com/manual/en/streamwrapper.stream-lock.php
+        if (strstr(PHP_VERSION, 'hiphop') !== false) {
+            $this->markTestSkipped('streamWrapper::stream_lock is not supported in HHVM.');
+        }
         $file = vfsStream::newFile('foo.txt')->at($this->root);
         $fp1 = fopen(vfsStream::url('root/foo.txt'), 'rb');
         $fp2 = fopen(vfsStream::url('root/foo.txt'), 'rb');


### PR DESCRIPTION
Skip certain tests using stream_lock when running under hhvm.
