### PR TITLE
remove PHP 5.6 from allow_failurs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 matrix:
   allow_failures:
     - php: hhvm
-    - php: 5.6
 
 before_script:
   - "mkdir -p ~/.composer"


### PR DESCRIPTION
PHP 5.6 stable release now.
