### PR TITLE
added test vfsStreamWrapperFileTestCase::cannotRenameNotWritableFile() to show added check in vfsStreamWrapper::rename() (only writeable files are renameable/moveable)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /docs
 /nbproject
 /vendor
+.idea

--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -774,6 +774,10 @@ class vfsStreamWrapper
             trigger_error('Target is not a directory', E_USER_WARNING);
             return false;
         }
+        if (!$srcContent->isWritable(vfsStream::getCurrentUser(), vfsStream::getCurrentGroup())) {
+            trigger_error('Permission denied', E_USER_WARNING);
+            return false;
+        }
 
         // remove old source first, so we can rename later
         // (renaming first would lead to not being able to remove the old path)

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperFileTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperFileTestCase.php
@@ -446,6 +446,18 @@ class vfsStreamWrapperFileTestCase extends vfsStreamWrapperBaseTestCase
 
     /**
      * @test
+     */
+    public function cannotRenameNotWritableFile()
+    {
+        $this->baz1->chmod(0400);
+        $oldName = $this->baz1->url();
+        $newName = $this->baz1->url() . '.new';
+
+        $this->assertFalse(@rename($oldName, $newName));
+    }
+
+    /**
+     * @test
      * @group issue_38
      */
     public function cannotReadFileFromNonReadableDir()


### PR DESCRIPTION
Hello,

I'm really crossing fingers to myself that I don't missed reading something or understand the whole read/write/execute rights management wrong but I tried to implement a unittest for an [upcomming project](https://github.com/stevleibelt/incubator/blob/master/cli/generate/locator/test/Test/Net/Bazzline/Component/Locator/FileExistsStrategy/SuffixWithCurrentTimestampStrategyTest.php) and could not make it working as expected.

It is about renaming / moving a filename to an other filename while the file has no write permission.
My expectation is, that I get back an "false" when I try to do this, but I did not get it. I am expecting the same for trying to unlink a not writable file, but this is a story for another pull request if the current pull request leads to the "acknowledged" status :-).

Finally, i added ".idea" to the ".gitignore" file to prevent adding phpstorm/jetbrains ide files by mistake.

Greetings and thanks so far for this great testing tool!
