### PR TITLE
fopen() takes two parameters instead of one.

### DIFF
--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperWithoutRootTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperWithoutRootTestCase.php
@@ -48,7 +48,7 @@ class vfsStreamWrapperWithoutRootTestCase extends \PHPUnit_Framework_TestCase
      */
     public function canNotOpen()
     {
-        $this->assertFalse(@fopen(vfsStream::url('foo')));
+        $this->assertFalse(@fopen(vfsStream::url('foo'), 'r'));
     }
 
     /**


### PR DESCRIPTION
Fix one of the function call error in vfsStreamWrapperWithoutRootTestCase, which fopen() should take two parameters instead of one.

If only pass in one parameter, fopen() return false because PHP's parameter parsing failed instead of the actual open failed.
