### PR TITLE
Mock fopen failure, closes #155

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamFile.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamFile.php
@@ -35,6 +35,10 @@ class vfsStreamFile extends vfsStreamAbstractContent
      * @type  bool[string]
      */
     protected $sharedLock = array();
+    /**
+     * @var null|string
+     */
+    private $openError;
 
     /**
      * constructor
@@ -390,5 +394,29 @@ class vfsStreamFile extends vfsStreamAbstractContent
         }
 
         return null !== $this->exclusiveLock;
+    }
+
+    /**
+     * Setter to set (string w/ content) or remove (null) triggering an error
+     * on a vfs-stream-wrapped fopen() call.
+     * 
+     * @param string|null $error string (non-zero length) to raise an error on fopen, null to unset (default)
+     * @since 1.6.5
+     * @see   https://github.com/mikey179/vfsStream/issues/155
+     */
+    public function setOpenError($error = null)
+    {
+        $this->openError = $error;
+    }
+
+    /**
+     * @see    setOpenError
+     * @return null|string
+     * @since  1.6.5
+     * @see    https://github.com/mikey179/vfsStream/issues/155
+     */
+    public function getOpenError()
+    {
+        return $this->openError;
     }
 }

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperFileTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperFileTestCase.php
@@ -454,4 +454,22 @@ class vfsStreamWrapperFileTestCase extends vfsStreamWrapperBaseTestCase
         $this->bar->chmod(0);
         $this->assertFalse(@file_get_contents($this->baz1URL));
     }
+
+    /**
+     * @test
+     * @see   https://github.com/mikey179/vfsStream/issues/155
+     * @since 1.6.5
+     */
+    public function errorOnOpen()
+    {
+        $file = $this->baz1;
+        $path = $file->url();
+        $this->assertNotFalse(@fopen($path, 'r'), 'precondition');
+
+        $file->setOpenError("fopen() gives error");
+        $this->assertFalse(@fopen($path, 'r'), 'fopen fails now');
+
+        $file->setOpenError(null);
+        $this->assertNotFalse(@fopen($path, 'r'), 'fopen works again');
+    }
 }


### PR DESCRIPTION
Feature to test fopen() error cases, to simulate race conditions on
fopen() that is when a readable file becomes unreadable on fopen()
instantly, for example to simulate a file-system failure.