### PR TITLE
Fix seeking past eof

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
     "autoload": {
         "psr-0": { "org\\bovigo\\vfs\\": "src/main/php" }
     },
+    "autoload-dev": {
+        "psr-4": { "org\\bovigo\\vfs\\test\\": "src/test/php/org/bovigo/vfs" }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0.x-dev"

--- a/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
@@ -55,13 +55,15 @@ abstract class SeekableFileContent implements FileContent
     public function seek(int $offset, int $whence): bool
     {
         $newOffset = $this->offset;
+        $size = $this->size();
+
         switch ($whence) {
             case SEEK_CUR:
                 $newOffset += $offset;
                 break;
 
             case SEEK_END:
-                $newOffset = $this->size() + $offset;
+                $newOffset = $size + $offset;
                 break;
 
             case SEEK_SET:
@@ -71,6 +73,11 @@ abstract class SeekableFileContent implements FileContent
             default:
                 return false;
         }
+
+        if ($newOffset > $size) {
+            $newOffset = $size;
+        }
+
 
         if ($newOffset < 0) {
             return false;

--- a/src/test/php/org/bovigo/vfs/content/SeekableFileContentTestCase.php
+++ b/src/test/php/org/bovigo/vfs/content/SeekableFileContentTestCase.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+/**
+ * This file is part of vfsStream.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package  org\bovigo\vfs
+ */
+namespace org\bovigo\vfs\content;
+
+use org\bovigo\vfs\test\content\resource\SeekableFileContentImplementation;
+use PHPUnit\Framework\TestCase;
+
+use function bovigo\assert\assertThat;
+use function bovigo\assert\predicate\isGreaterThanOrEqualTo;
+
+/**
+ * Test for org\bovigo\vfs\content\SeekableFileContent.
+ *
+ * @since  1.6.6
+ * @group  issue_169
+ */
+class SeekableFileContentTestCase extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function cannotReturnOffsetPastEof()
+    {
+
+        $size = 100;
+
+        $file = new SeekableFileContentImplementation();
+        $file->setSize($size);
+
+        $file->seek($size + 10, SEEK_SET);
+
+        assertThat($file->bytesRead(), isGreaterThanOrEqualTo($size));
+
+    }
+
+}
+

--- a/src/test/php/org/bovigo/vfs/content/resource/SeekableFileContentImplementation.php
+++ b/src/test/php/org/bovigo/vfs/content/resource/SeekableFileContentImplementation.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace org\bovigo\vfs\test\content\resource;
+
+use org\bovigo\vfs\content\SeekableFileContent;
+
+class SeekableFileContentImplementation extends SeekableFileContent
+{
+
+    private $size;
+
+    public function size(): int
+    {
+        return $this->size;
+    }
+
+    public function setSize(int $size)
+    {
+        $this->size = $size;
+    }
+
+    protected function doRead(int $offset, int $count): string
+    {
+        // functionality not required for testing
+    }
+
+    protected function doWrite(string $data, int $offset, int $length)
+    {
+        // functionality not required for testing
+    }
+
+    public function content(): string
+    {
+        // functionality not required for testing
+    }
+
+    public function truncate(int $size): bool
+    {
+        // functionality not required for testing
+    }
+
+}

--- a/src/test/php/org/bovigo/vfs/vfsStreamFileTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamFileTestCase.php
@@ -219,9 +219,9 @@ class vfsStreamFileTestCase extends TestCase
     {
       return [
           [0, SEEK_SET, 0, 'foobarbaz'],
-          [5, SEEK_SET, 5, 'rbaz'],
+          [5, SEEK_SET, 0, 'rbaz'],
           [0, SEEK_END, 0, ''],
-          [2, SEEK_END, 2, ''],
+          [2, SEEK_END, 0, ''],
       ];
     }
 
@@ -242,9 +242,9 @@ class vfsStreamFileTestCase extends TestCase
     {
         $this->file->seek(5, SEEK_SET);
         assertTrue($this->file->seek(0, SEEK_CUR));
-        assertThat($this->file->getBytesRead(), equals(5));
+        assertThat($this->file->getBytesRead(), equals(0));
         assertTrue($this->file->seek(2, SEEK_CUR));
-        assertThat($this->file->getBytesRead(), equals(7));
+        assertThat($this->file->getBytesRead(), equals(0));
     }
 
     /**
@@ -257,9 +257,20 @@ class vfsStreamFileTestCase extends TestCase
         assertThat($this->file->getBytesRead(), equals(0));
     }
 
+    public function seekReads(): array
+    {
+        return [
+            [0, SEEK_SET, 0, 'foobarbaz'],
+            [5, SEEK_SET, 5, 'rbaz'],
+            [0, SEEK_END, 0, ''],
+            [2, SEEK_END, 0, ''],
+            [-2, SEEK_END, -2, 'az'],
+        ];
+    }
+
     /**
      * @test
-     * @dataProvider  seeks
+     * @dataProvider  seekReads
      */
     public function seekRead(int $offset, $whence, int $expected, string $remaining)
     {

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperFileTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperFileTestCase.php
@@ -130,7 +130,7 @@ class vfsStreamWrapperFileTestCase extends vfsStreamWrapperBaseTestCase
         return [
             [2, SEEK_SET, 2],
             [1, SEEK_CUR, 1],
-            [1, SEEK_END, 7],
+            [1, SEEK_END, 6],
         ];
     }
 


### PR DESCRIPTION
Fixes #169 

Apologies for having to add the `autoload-dev` to composer. I couldn't work out another way of testing the abstract class `SeekableFileContent` in isolation.
I'm open to ideas if you don't like this.