### PR TITLE
Fix for 7.3: streamed directory are now also executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperTestCase.php
@@ -255,11 +255,18 @@ class vfsStreamWrapperTestCase extends vfsStreamWrapperBaseTestCase
     /**
      * @test
      */
-    public function directoriesAreNeverExecutable()
+    public function directoriesAreSometimesExecutable()
     {
         $this->root->chmod(0766);
-        assertFalse(is_executable($this->root->url()));
-        assertFalse(is_executable($this->root->url() . '/.'));
+        // Inconsistent behavior has been fixed in 7.3
+        // see https://github.com/php/php-src/commit/94b4abdbc4d
+        if (PHP_VERSION_ID >= 70300) {
+            assertTrue(is_executable($this->root->url()));
+            assertTrue(is_executable($this->root->url() . '/.'));
+        } else {
+            assertFalse(is_executable($this->root->url()));
+            assertFalse(is_executable($this->root->url() . '/.'));
+        }
     }
 
     /**


### PR DESCRIPTION
Catched in Fedoa QA
https://apps.fedoraproject.org/koschei/package/php-mikey179-vfsstream?collection=f30

The PHP 7.3 behavior have changed, more explanation on 
https://github.com/php/php-src/commit/94b4abdbc4d