### PR TITLE
Fix: Use lower-case for package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mikey179/vfsStream",
+    "name": "mikey179/vfsstream",
     "type": "library",
     "homepage": "http://vfs.bovigo.org/",
     "description": "Virtual file system to mock the real file system in unit tests.",


### PR DESCRIPTION
This PR

* [x] uses lower-case for the package name in `composer.json`

💁‍♂️ Following an update of `composer` to `1.8.1`, the following message is emitted when running related `composer` commands

>Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase 
characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.

For reference, see https://github.com/composer/composer/releases/tag/1.8.1.