### PR TITLE
Fix `@type` to `@var`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
   * raised minimum required PHP version to 7.2.0
   * all methods of `org\bovigo\vfs\visitor\vfsStreamVisitor` are now declared with `self` as return type
+  * `vfsStreamWrapper::setRoot()` and `vsfStreamWrapper::getRoot()` method signatures now require and return `org\bovigo\vfs\vfsStreamDirectory` vice `org\bovigo\vfs\vfsStreamContainer`.
 
 
 1.6.6 (2019-04-08)

--- a/src/main/php/org/bovigo/vfs/Quota.php
+++ b/src/main/php/org/bovigo/vfs/Quota.php
@@ -26,7 +26,7 @@ class Quota
      *
      * A value of -1 is treated as unlimited.
      *
-     * @type  int
+     * @var  int
      */
     private $amount;
 

--- a/src/main/php/org/bovigo/vfs/content/FileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/FileContent.php
@@ -69,4 +69,22 @@ interface FileContent
      * @return  bool
      */
     public function truncate(int $size): bool;
+
+    /**
+     * Returns the current position within the file.
+     *
+     * @return  int
+     * @api
+     */
+    public function bytesRead(): int;
+
+    /**
+     * Returns the content until its end from current offset.
+     *
+     * Using this method changes the time when the file was last accessed.
+     *
+     * @return  string
+     * @api
+     */
+    public function readUntilEnd(): string;
 }

--- a/src/main/php/org/bovigo/vfs/content/LargeFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/LargeFileContent.php
@@ -28,13 +28,13 @@ class LargeFileContent extends SeekableFileContent implements FileContent
     /**
      * byte array of written content
      *
-     * @type  char[]
+     * @var  array
      */
     private $content = [];
     /**
      * file size in bytes
      *
-     * @type  int
+     * @var  int
      */
     private $size;
 

--- a/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
@@ -117,7 +117,7 @@ abstract class SeekableFileContent implements FileContent
      * for backwards compatibility with vfsStreamFile::bytesRead()
      *
      * @return  int
-     * @deprecated
+     * @api
      */
     public function bytesRead(): int
     {
@@ -128,7 +128,7 @@ abstract class SeekableFileContent implements FileContent
      * for backwards compatibility with vfsStreamFile::readUntilEnd()
      *
      * @return  string
-     * @deprecated
+     * @api
      */
     public function readUntilEnd(): string
     {

--- a/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
@@ -19,7 +19,7 @@ abstract class SeekableFileContent implements FileContent
     /**
      * current position within content
      *
-     * @type  int
+     * @var  int
      */
     private $offset = 0;
 

--- a/src/main/php/org/bovigo/vfs/content/StringBasedFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/StringBasedFileContent.php
@@ -19,7 +19,7 @@ class StringBasedFileContent extends SeekableFileContent implements FileContent
     /**
      * actual content
      *
-     * @type  string
+     * @var  string
      */
     private $content;
 

--- a/src/main/php/org/bovigo/vfs/vfsStream.php
+++ b/src/main/php/org/bovigo/vfs/vfsStream.php
@@ -50,13 +50,13 @@ class vfsStream
     /**
      * initial umask setting
      *
-     * @type  int
+     * @var  int
      */
     protected static $umask  = 0000;
     /**
      * switch whether dotfiles are enabled in directory listings
      *
-     * @type  bool
+     * @var  bool
      */
     private static $dotFiles = true;
 

--- a/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
@@ -23,7 +23,7 @@ abstract class vfsStreamAbstractContent implements vfsStreamContent
     /**
      * type of the container
      *
-     * @var  string
+     * @var  int
      */
     protected $type;
     /**
@@ -65,15 +65,15 @@ abstract class vfsStreamAbstractContent implements vfsStreamContent
     /**
      * path to to this content
      *
-     * @var  string
+     * @var  string|null
      */
     private $parentPath;
 
     /**
      * constructor
      *
-     * @param  string  $name
-     * @param  int     $permissions  optional
+     * @param  string    $name
+     * @param  int|null  $permissions  optional
      */
     public function __construct(string $name, int $permissions = null)
     {

--- a/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
@@ -17,55 +17,55 @@ abstract class vfsStreamAbstractContent implements vfsStreamContent
     /**
      * name of the container
      *
-     * @type  string
+     * @var  string
      */
     protected $name;
     /**
      * type of the container
      *
-     * @type  string
+     * @var  string
      */
     protected $type;
     /**
      * timestamp of last access
      *
-     * @type  int
+     * @var  int
      */
     protected $lastAccessed;
     /**
      * timestamp of last attribute modification
      *
-     * @type  int
+     * @var  int
      */
     protected $lastAttributeModified;
     /**
      * timestamp of last modification
      *
-     * @type  int
+     * @var  int
      */
     protected $lastModified;
     /**
      * permissions for content
      *
-     * @type  int
+     * @var  int
      */
     protected $permissions;
     /**
      * owner of the file
      *
-     * @type  int
+     * @var  int
      */
     protected $user;
     /**
      * owner group of the file
      *
-     * @type  int
+     * @var  int
      */
     protected $group;
     /**
      * path to to this content
      *
-     * @type  string
+     * @var  string
      */
     private $parentPath;
 

--- a/src/main/php/org/bovigo/vfs/vfsStreamContainerIterator.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamContainerIterator.php
@@ -17,7 +17,7 @@ class vfsStreamContainerIterator implements \Iterator
     /**
      * list of children from container to iterate over
      *
-     * @type  vfsStreamContent[]
+     * @var  vfsStreamContent[]
      */
     protected $children;
 

--- a/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
@@ -73,7 +73,7 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
     {
         $size = 0;
         foreach ($this->children as $child) {
-            if ($child->getType() === vfsStreamContent::TYPE_DIR) {
+            if ($child instanceof self) {
                 $size += $child->sizeSummarized();
             } else {
                 $size += $child->size();
@@ -181,7 +181,11 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
                 return $child;
             }
 
-            if ($child->appliesTo($childName) === true && $child->hasChild($childName) === true) {
+            if (!$child instanceof vfsStreamContainer) {
+                continue;
+            }
+
+            if ($child->appliesTo($childName) && $child->hasChild($childName)) {
                 return $child->getChild($childName);
             }
         }

--- a/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
@@ -19,7 +19,7 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
     /**
      * list of directory children
      *
-     * @type  vfsStreamContent[]
+     * @var  vfsStreamContent[]
      */
     protected $children = [];
 

--- a/src/main/php/org/bovigo/vfs/vfsStreamFile.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamFile.php
@@ -27,13 +27,13 @@ class vfsStreamFile extends vfsStreamAbstractContent
     /**
      * Resource id which exclusively locked this file
      *
-     * @var  string
+     * @var  string|null
      */
     protected $exclusiveLock;
     /**
      * Resources ids which currently holds shared lock to this file
      *
-     * @var  bool[string]
+     * @var  array<string, bool>
      */
     protected $sharedLock = [];
 
@@ -366,7 +366,8 @@ class vfsStreamFile extends vfsStreamAbstractContent
      * @return  string
      * @see     https://github.com/mikey179/vfsStream/issues/40
      */
-    public function getResourceId($resource): string {
+    public function getResourceId($resource): string
+    {
         if (is_resource($resource)) {
             $data = stream_get_meta_data($resource);
             $resource = $data['wrapper_data'];

--- a/src/main/php/org/bovigo/vfs/vfsStreamFile.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamFile.php
@@ -21,19 +21,19 @@ class vfsStreamFile extends vfsStreamAbstractContent
     /**
      * content of the file
      *
-     * @type  FileContent
+     * @var  FileContent
      */
     private $content;
     /**
      * Resource id which exclusively locked this file
      *
-     * @type  string
+     * @var  string
      */
     protected $exclusiveLock;
     /**
      * Resources ids which currently holds shared lock to this file
      *
-     * @type  bool[string]
+     * @var  bool[string]
      */
     protected $sharedLock = [];
 

--- a/src/main/php/org/bovigo/vfs/vfsStreamFile.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamFile.php
@@ -176,7 +176,7 @@ class vfsStreamFile extends vfsStreamAbstractContent
      * Using this method changes the time when the file was last accessed.
      *
      * @return  string
-     * @deprecated  since 1.3.0
+     * @api  since 1.3.0
      */
     public function readUntilEnd(): string
     {
@@ -226,7 +226,7 @@ class vfsStreamFile extends vfsStreamAbstractContent
      * returns the current position within the file
      *
      * @return  int
-     * @deprecated  since 1.3.0
+     * @api  since 1.3.0
      */
     public function getBytesRead(): int
     {

--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -50,43 +50,43 @@ class vfsStreamWrapper
     /**
      * switch whether class has already been registered as stream wrapper or not
      *
-     * @type  bool
+     * @var  bool
      */
     protected static $registered = false;
     /**
      * root content
      *
-     * @type  vfsStreamContent
+     * @var  vfsStreamContent
      */
     protected static $root;
     /**
      * disk space quota
      *
-     * @type  Quota
+     * @var  Quota
      */
     private static $quota;
     /**
      * file mode: read only, write only, all
      *
-     * @type  int
+     * @var  int
      */
     protected $mode;
     /**
      * shortcut to file container
      *
-     * @type  vfsStreamFile
+     * @var  vfsStreamFile
      */
     protected $content;
     /**
      * shortcut to directory container
      *
-     * @type  vfsStreamDirectory
+     * @var  vfsStreamDirectory
      */
     protected $dir;
     /**
      * shortcut to directory container iterator
      *
-     * @type  vfsStreamDirectory
+     * @var  vfsStreamDirectory
      */
     protected $dirIterator;
 

--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -56,7 +56,7 @@ class vfsStreamWrapper
     /**
      * root content
      *
-     * @var  vfsStreamContent
+     * @var  vfsStreamDirectory|null
      */
     protected static $root;
     /**
@@ -74,19 +74,19 @@ class vfsStreamWrapper
     /**
      * shortcut to file container
      *
-     * @var  vfsStreamFile
+     * @var  vfsStreamFile|null
      */
     protected $content;
     /**
      * shortcut to directory container
      *
-     * @var  vfsStreamDirectory
+     * @var  vfsStreamDirectory|null
      */
     protected $dir;
     /**
      * shortcut to directory container iterator
      *
-     * @var  vfsStreamDirectory
+     * @var  vfsStreamContainerIterator|null
      */
     protected $dirIterator;
 
@@ -146,10 +146,10 @@ class vfsStreamWrapper
     /**
      * sets the root content
      *
-     * @param   vfsStreamContainer  $root
-     * @return  vfsStreamContainer|null
+     * @param   vfsStreamDirectory  $root
+     * @return  vfsStreamDirectory
      */
-    public static function setRoot(vfsStreamContainer $root): ?vfsStreamContainer
+    public static function setRoot(vfsStreamDirectory $root): vfsStreamDirectory
     {
         self::$root = $root;
         clearstatcache();
@@ -159,9 +159,9 @@ class vfsStreamWrapper
     /**
      * returns the root content
      *
-     * @return  vfsStreamContainer|null
+     * @return  vfsStreamDirectory|null
      */
-    public static function getRoot(): ?vfsStreamContainer
+    public static function getRoot(): ?vfsStreamDirectory
     {
         return self::$root;
     }

--- a/src/main/php/org/bovigo/vfs/visitor/vfsStreamPrintVisitor.php
+++ b/src/main/php/org/bovigo/vfs/visitor/vfsStreamPrintVisitor.php
@@ -24,13 +24,13 @@ class vfsStreamPrintVisitor extends vfsStreamAbstractVisitor
     /**
      * target to write output to
      *
-     * @type  resource
+     * @var  resource
      */
     protected $out;
     /**
      * current depth in directory tree
      *
-     * @type  int
+     * @var  int
      */
     protected $depth = 0;
 

--- a/src/main/php/org/bovigo/vfs/visitor/vfsStreamStructureVisitor.php
+++ b/src/main/php/org/bovigo/vfs/visitor/vfsStreamStructureVisitor.php
@@ -24,13 +24,13 @@ class vfsStreamStructureVisitor extends vfsStreamAbstractVisitor
     /**
      * collected structure
      *
-     * @type  array
+     * @var  array
      */
     protected $structure = [];
     /**
      * poiting to currently iterated directory
      *
-     * @type  array
+     * @var  array
      */
     protected $current;
 


### PR DESCRIPTION
- Replaced `@type` with `@var`
  - `@type` is not a valid [phpdoc](https://docs.phpdoc.org/references/phpdoc/index.html) tag. 
  - `@var` helps static analysis tools identify what properties should contain.
- Fixed phpstan errors 
- Updated `@deprecated` to `@api` based on [this discussion](https://github.com/orgs/bovigo/teams/vfsstream/discussions/2)
