### PR TITLE
Change methods to internal

### DIFF
--- a/src/main/php/org/bovigo/vfs/content/FileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/FileContent.php
@@ -74,7 +74,7 @@ interface FileContent
      * Returns the current position within the file.
      *
      * @return  int
-     * @api
+     * @internal
      */
     public function bytesRead(): int;
 
@@ -84,7 +84,7 @@ interface FileContent
      * Using this method changes the time when the file was last accessed.
      *
      * @return  string
-     * @api
+     * @internal
      */
     public function readUntilEnd(): string;
 }

--- a/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
@@ -117,7 +117,7 @@ abstract class SeekableFileContent implements FileContent
      * for backwards compatibility with vfsStreamFile::bytesRead()
      *
      * @return  int
-     * @api
+     * @internal
      */
     public function bytesRead(): int
     {
@@ -128,7 +128,7 @@ abstract class SeekableFileContent implements FileContent
      * for backwards compatibility with vfsStreamFile::readUntilEnd()
      *
      * @return  string
-     * @api
+     * @internal
      */
     public function readUntilEnd(): string
     {

--- a/src/main/php/org/bovigo/vfs/vfsStreamFile.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamFile.php
@@ -176,7 +176,7 @@ class vfsStreamFile extends vfsStreamAbstractContent
      * Using this method changes the time when the file was last accessed.
      *
      * @return  string
-     * @api  since 1.3.0
+     * @internal  since 1.3.0
      */
     public function readUntilEnd(): string
     {
@@ -226,7 +226,7 @@ class vfsStreamFile extends vfsStreamAbstractContent
      * returns the current position within the file
      *
      * @return  int
-     * @api  since 1.3.0
+     * @internal  since 1.3.0
      */
     public function getBytesRead(): int
     {


### PR DESCRIPTION
- These were previously marked as deprecated, then switched to `@api`.
- Switching to `@internal` per [this comment](https://github.com/bovigo/vfsStream/pull/186#issuecomment-484020654)