### PR TITLE
Throw exception if filename contains slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   * raised minimum required PHP version to 7.2.0
   * all methods of `org\bovigo\vfs\visitor\vfsStreamVisitor` are now declared with `self` as return type
   * `vfsStreamWrapper::setRoot()` and `vsfStreamWrapper::getRoot()` method signatures now require and return `org\bovigo\vfs\vfsStreamDirectory` vice `org\bovigo\vfs\vfsStreamContainer`.
-  * `vfsStream::newFile()` and `org\bovigo\vfs\vfsStreamFile` will throw an exception if the filename contains a forward slash (`/`).
+  * `vfsStream::newFile()`, `vfsStream::newBlock()`, `org\bovigo\vfs\vfsStreamFile`, and `org\bovigo\vfs\vfsStreamBlock` will throw an exception if the filename contains a forward slash (`/`).
 
 
 1.6.6 (2019-04-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * raised minimum required PHP version to 7.2.0
   * all methods of `org\bovigo\vfs\visitor\vfsStreamVisitor` are now declared with `self` as return type
   * `vfsStreamWrapper::setRoot()` and `vsfStreamWrapper::getRoot()` method signatures now require and return `org\bovigo\vfs\vfsStreamDirectory` vice `org\bovigo\vfs\vfsStreamContainer`.
+  * `vfsStream::newFile()` and `org\bovigo\vfs\vfsStreamFile` will throw an exception if the filename contains a forward slash (`/`).
 
 
 1.6.6 (2019-04-08)

--- a/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
@@ -77,6 +77,10 @@ abstract class vfsStreamAbstractContent implements vfsStreamContent
      */
     public function __construct(string $name, int $permissions = null)
     {
+        if (strstr($name, '/') !== false) {
+            throw new vfsStreamException('Name can not contain /.');
+        }
+
         $this->name = "{$name}";
         $time       = time();
         if (null === $permissions) {
@@ -116,6 +120,10 @@ abstract class vfsStreamAbstractContent implements vfsStreamContent
      */
     public function rename(string $newName)
     {
+        if (strstr($newName, '/') !== false) {
+            throw new vfsStreamException('Name can not contain /.');
+        }
+
         $this->name = "{$newName}";
     }
 

--- a/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
@@ -32,10 +32,6 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
      */
     public function __construct(string $name, int $permissions = null)
     {
-        if (strstr($name, '/') !== false) {
-            throw new vfsStreamException('Directory name can not contain /.');
-        }
-
         $this->type = vfsStreamContent::TYPE_DIR;
         parent::__construct($name, $permissions);
     }
@@ -82,22 +78,6 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
 
         return $size;
     }
-
-    /**
-     * renames the content
-     *
-     * @param   string  $newName
-     * @throws  vfsStreamException
-     */
-    public function rename(string $newName)
-    {
-        if (strstr($newName, '/') !== false) {
-            throw new vfsStreamException('Directory name can not contain /.');
-        }
-
-        parent::rename($newName);
-    }
-
 
     /**
      * sets parent path

--- a/src/test/php/org/bovigo/vfs/vfsStreamAbstractContentTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamAbstractContentTestCase.php
@@ -13,7 +13,10 @@ use bovigo\callmap\NewInstance;
 use PHPUnit\Framework\TestCase;
 
 use function bovigo\assert\assertFalse;
+use function bovigo\assert\assertThat;
 use function bovigo\assert\assertTrue;
+use function bovigo\assert\expect;
+use function bovigo\assert\predicate\equals;
 /**
  * Test for org\bovigo\vfs\vfsStreamAbstractContent.
  */
@@ -28,6 +31,16 @@ class vfsStreamAbstractContentTestCase extends TestCase
                 'getDefaultPermissions' => 0777,
                 'size'                  => 0
             ]);
+    }
+
+    /**
+     * @test
+     */
+    public function invalidCharacterInNameThrowsException()
+    {
+        expect(function () {
+            NewInstance::of(vfsStreamAbstractContent::class, ['foo/bar']);
+        })->throws(vfsStreamException::class);
     }
 
     /**
@@ -688,5 +701,29 @@ class vfsStreamAbstractContentTestCase extends TestCase
         ));
         assertFalse($content->isExecutable(self::OTHER, vfsStream::getCurrentGroup()));
         assertTrue($content->isExecutable(self::OTHER, self::OTHER));
+    }
+
+    /**
+     * @test
+     */
+    public function canBeRenamed()
+    {
+        $content = $this->createContent(0600);
+        $content->rename('bar');
+        assertThat($content->getName(), equals('bar'));
+        assertFalse($content->appliesTo('foo'));
+        assertFalse($content->appliesTo('foo/bar'));
+        assertTrue($content->appliesTo('bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function renameToInvalidNameThrowsException()
+    {
+        $content = $this->createContent(0600);
+        expect(function () use ($content) {
+            $content->rename('foo/baz');
+        })->throws(vfsStreamException::class);
     }
 }

--- a/src/test/php/org/bovigo/vfs/vfsStreamFileTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamFileTestCase.php
@@ -42,6 +42,15 @@ class vfsStreamFileTestCase extends TestCase
     /**
      * @test
      */
+    public function invalidCharacterInNameThrowsException()
+    {
+        expect(function() { new vfsStreamFile('foo/bar'); })
+            ->throws(vfsStreamException::class);
+    }
+
+    /**
+     * @test
+     */
     public function isOfTypeFile()
     {
         assertThat($this->file->getType(), equals(vfsStreamContent::TYPE_FILE));
@@ -89,6 +98,15 @@ class vfsStreamFileTestCase extends TestCase
         assertFalse($this->file->appliesTo('foo'));
         assertFalse($this->file->appliesTo('foo/bar'));
         assertTrue($this->file->appliesTo('bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function renameToInvalidNameThrowsException()
+    {
+        expect(function() { $this->file->rename('foo/baz'); })
+            ->throws(vfsStreamException::class);
     }
 
     /**

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperDirSeparatorTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperDirSeparatorTestCase.php
@@ -42,8 +42,10 @@ class vfsStreamWrapperDirSeparatorTestCase extends TestCase
      */
     public function fileCanBeAccessedUsingWinDirSeparator()
     {
-        vfsStream::newFile('foo/bar/baz.txt')
-                 ->at($this->root)
+        $structure = ['foo' => ['bar' => []]];
+        vfsStream::create($structure, $this->root);
+        vfsStream::newFile('baz.txt')
+                 ->at($this->root->getChild('foo')->getChild('bar'))
                  ->withContent('test');
         assertThat(file_get_contents('vfs://root/foo\bar\baz.txt'), equals('test'));
     }


### PR DESCRIPTION
- Throw exception if `vfsStreamFile` contains a slash in the name.
  - This resolves #142.
  - This is the same behavior that `vfsStreamDirectory` has.
