### PR TITLE
String offset access syntax with curly braces (PHP 7.4 compat)

### DIFF
--- a/src/main/php/org/bovigo/vfs/content/LargeFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/LargeFileContent.php
@@ -132,7 +132,7 @@ class LargeFileContent extends SeekableFileContent implements FileContent
     protected function doWrite(string $data, int $offset, int $length)
     {
         for ($i = 0; $i < $length; $i++) {
-            $this->content[$i + $offset] = $data{$i};
+            $this->content[$i + $offset] = substr($data, $i, 1);
         }
 
         if ($offset >= $this->size) {

--- a/src/main/php/org/bovigo/vfs/vfsStream.php
+++ b/src/main/php/org/bovigo/vfs/vfsStream.php
@@ -353,7 +353,7 @@ class vfsStream
      */
     public static function newDirectory(string $name, int $permissions = null): vfsStreamDirectory
     {
-        if ('/' === $name{0}) {
+        if ('/' === substr($name, 0, 1)) {
             $name = substr($name, 1);
         }
 


### PR DESCRIPTION
[Array and string offset access syntax with curly braces is deprecated](https://wiki.php.net/rfc/deprecate_curly_braces_array_access) in PHP 7.4, this change will prevent notice from being issued.

Thanks!