### PR TITLE
Update CHANGELOG for 1.6.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.6.7 (2019-07-31)
+------------------
+
+   * fix PHP 7.4 deprecation warnings (backported #189 from master)
+
 1.6.6 (2019-04-08)
 ------------------
 


### PR DESCRIPTION
Do we have a formalized release process for new tags? Otherwise, here's the update to our changelog.

Closes #195