### PR TITLE
Introduce travis stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,20 +23,17 @@ matrix:
     - php: 7.4snapshot
 
 install:
-  - composer install
+  - phpenv config-rm xdebug.ini
+  - if [ "$DEPENDENCIES" = "default" ]; then composer install --prefer-dist; fi;
+  - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
+  - if [ "$DEPENDENCIES" = "highest" ]; then composer update --prefer-dist -n; fi;
+  - composer show
+
+script:
+  - vendor/bin/phpunit
 
 jobs:
   include:
-    - stage: test
-      before_script:
-        - phpenv config-rm xdebug.ini
-        - if [ "$DEPENDENCIES" = "default" ]; then composer install --prefer-dist; fi;
-        - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
-        - if [ "$DEPENDENCIES" = "highest" ]; then composer update --prefer-dist -n; fi;
-        - composer show
-      script:
-        - vendor/bin/phpunit
-
     - stage: analyze
       name: phpstan
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
   - DEPENDENCIES=lowest
   - DEPENDENCIES=highest
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ php:
   - 7.4snapshot
   - nightly
 
+env:
+  - DEPENDENCIES=default
+  - DEPENDENCIES=lowest
+  - DEPENDENCIES=highest
+
+
 matrix:
   fast_finish: true
   allow_failures:
@@ -16,10 +22,27 @@ matrix:
 install:
   - composer install
 
-script:
-  - vendor/bin/phpunit --coverage-text
-  - vendor/bin/phpstan analyze
-
-after_success:
-  - composer require php-coveralls/php-coveralls
-  - travis_retry vendor/bin/php-coveralls
+jobs:
+  include:
+    - stage: test
+      install:
+        - if [ "$DEPENDENCIES" = "default" ]; then composer install --prefer-dist; fi;
+        - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
+        - if [ "$DEPENDENCIES" = "highest" ]; then composer update --prefer-dist -n; fi;
+        - composer show
+      script:
+        - vendor/bin/phpunit
+    - stage: analyze
+      name: phpstan
+      script:
+        - vendor/bin/phpstan analyze
+    - stage: analyze
+      name: Code style
+      script:
+        - vendor/bin/phpcs
+    - stage: analyze
+      name: code coverage
+      script:
+        - vendor/bin/phpunit --coverage-text
+        - composer require php-coveralls/php-coveralls
+        - travis_retry vendor/bin/php-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ install:
 jobs:
   include:
     - stage: test
+      before_install:
+        - phpenv config-rm xdebug.ini
       install:
         - if [ "$DEPENDENCIES" = "default" ]; then composer install --prefer-dist; fi;
         - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
@@ -32,14 +34,17 @@ jobs:
         - composer show
       script:
         - vendor/bin/phpunit
+
     - stage: analyze
       name: phpstan
       script:
         - vendor/bin/phpstan analyze
+
     - stage: analyze
       name: Code style
       script:
         - vendor/bin/phpcs
+
     - stage: analyze
       name: code coverage
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,8 @@ install:
 jobs:
   include:
     - stage: test
-      before_install:
+      before_script:
         - phpenv config-rm xdebug.ini
-      install:
         - if [ "$DEPENDENCIES" = "default" ]; then composer install --prefer-dist; fi;
         - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
         - if [ "$DEPENDENCIES" = "highest" ]; then composer update --prefer-dist -n; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
     - php: 7.4snapshot
 
 install:
-  - phpenv config-rm xdebug.ini
   - if [ "$DEPENDENCIES" = "default" ]; then composer install --prefer-dist; fi;
   - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
   - if [ "$DEPENDENCIES" = "highest" ]; then composer update --prefer-dist -n; fi;
   - composer show
 
 script:
+  - phpenv config-rm xdebug.ini || true
   - vendor/bin/phpunit
 
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "bovigo/callmap": "^5.0",
+        "bovigo/callmap": "^5.0.1",
         "bovigo/assert": "^5.0",
         "phpstan/phpstan": "^0.11.5",
         "phpstan/phpstan-phpunit": "^0.11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79d8ffd2cfcd6564e7ed25a66da460be",
+    "content-hash": "3f346ea1af2c802fbf9880a6bd6922a4",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
In this pr I introduced build stages in travis setup. To make more clear what is happening. Besides that, I introduced an environment variable `DEPENDENCIES` which extends the build matrix with a second axel. Since we are building a library that supports a range of versions of its dependencies we should test against that range. From now on we are sure that all tests will pass on our lowest and highest dependencies. 

now executed:
- phpstan
- phpcs
- phpunit
- coverage phpunit