### PR TITLE
Fix StringBasedFileContent::doRead to always return a string

### DIFF
--- a/src/main/php/org/bovigo/vfs/content/StringBasedFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/StringBasedFileContent.php
@@ -60,7 +60,7 @@ class StringBasedFileContent extends SeekableFileContent implements FileContent
      */
     protected function doRead($offset, $count)
     {
-        return substr($this->content, $offset, $count);
+        return (string) substr($this->content, $offset, $count);
     }
 
     /**

--- a/src/test/php/org/bovigo/vfs/content/StringBasedFileContentTestCase.php
+++ b/src/test/php/org/bovigo/vfs/content/StringBasedFileContentTestCase.php
@@ -86,8 +86,10 @@ class StringBasedFileContentTestCase extends \BC_PHPUnit_Framework_TestCase
      */
     public function readAfterEndReturnsEmptyString()
     {
-        $this->stringBasedFileContent->read(9);
-        $this->assertEquals('', $this->stringBasedFileContent->read(3));
+        // Read more than the length of the string to test substr() returning
+        // false.
+        $this->stringBasedFileContent->read(10);
+        $this->assertSame('', $this->stringBasedFileContent->read(3));
     }
 
     /**

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperTestCase.php
@@ -777,4 +777,13 @@ class vfsStreamWrapperTestCase extends vfsStreamWrapperBaseTestCase
         $this->assertTrue(rename($this->baz1URL, $baz3URL));
         $this->assertEquals($baz3URL, $this->baz1->url());
     }
+
+    /**
+     * @test
+     */
+    public function fileCopy()
+    {
+        $baz3URL = vfsStream::url('foo/baz3');
+        $this->assertTrue(copy($this->baz1URL, $baz3URL));
+    }
 }


### PR DESCRIPTION
Drupal's testing on PHP 7.4 has found an issue on PHP 7.4 when copying a vfsStream file. It's caused by the fact that \org\bovigo\vfs\content\StringBasedFileContent::doRead() can return false because of the behaviour of substr() - see https://3v4l.org/BiKch