### PR TITLE
Add an erroneous file for triggering failure cases

### DIFF
--- a/src/vfsStream.php
+++ b/src/vfsStream.php
@@ -375,6 +375,32 @@ class vfsStream
     }
 
     /**
+     * Returns a new erroneous file with given name.
+     *
+     * Allows for throwing an error during fopen, fwrite, etc.
+     *
+     * For example:
+     *
+     * $file = vfsStream::newErroneousFile('foo.txt', ['open' => 'error message']);
+     *
+     * Will generate a file that always fails on open and displays "error message".
+     *
+     * You can set errors for: open, read, write, truncate, tell, seek, stat,
+     * eof, and lock.
+     *
+     * @param string   $name          name of file to create
+     * @param string[] $errorMessages Formatted as [action => message], e.g. ['open' => 'error message']
+     * @param int|null $permissions   permissions of file to create
+     */
+    public static function newErroneousFile(
+        string $name,
+        array $errorMessages,
+        ?int $permissions = null
+    ): vfsStreamErroneousFile {
+        return new vfsStreamErroneousFile($name, $errorMessages, $permissions);
+    }
+
+    /**
      * returns a new directory with given name
      *
      * If the name contains slashes, a new directory structure will be created.

--- a/src/vfsStreamErroneousFile.php
+++ b/src/vfsStreamErroneousFile.php
@@ -187,7 +187,7 @@ class vfsStreamErroneousFile extends vfsStreamFile
         if (isset($this->errorMessages['stat'])) {
             trigger_error($this->errorMessages['stat'], E_USER_WARNING);
 
-            return 0;
+            return -1;
         }
 
         return parent::size();
@@ -215,7 +215,7 @@ class vfsStreamErroneousFile extends vfsStreamFile
         if (isset($this->errorMessages['stat'])) {
             trigger_error($this->errorMessages['stat'], E_USER_WARNING);
 
-            return 0;
+            return -1;
         }
 
         return parent::filemtime();
@@ -229,7 +229,7 @@ class vfsStreamErroneousFile extends vfsStreamFile
         if (isset($this->errorMessages['stat'])) {
             trigger_error($this->errorMessages['stat'], E_USER_WARNING);
 
-            return 0;
+            return -1;
         }
 
         return parent::fileatime();
@@ -243,7 +243,7 @@ class vfsStreamErroneousFile extends vfsStreamFile
         if (isset($this->errorMessages['stat'])) {
             trigger_error($this->errorMessages['stat'], E_USER_WARNING);
 
-            return 0;
+            return -1;
         }
 
         return parent::filectime();

--- a/src/vfsStreamErroneousFile.php
+++ b/src/vfsStreamErroneousFile.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of vfsStream.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace bovigo\vfs;
+
+use const E_USER_WARNING;
+use function trigger_error;
+
+/**
+ * File to trigger errors on specific actions.
+ *
+ * Allows for throwing an error during fopen, fwrite, etc.
+ *
+ * @api
+ */
+class vfsStreamErroneousFile extends vfsStreamFile
+{
+    /** @var string[] */
+    private $errorMessages;
+
+    /**
+     * @param string[] $errorMessages Formatted as [action => message], e.g. ['open' => 'error message']
+     * @param int|null $permissions   optional
+     */
+    public function __construct(string $name, array $errorMessages, ?int $permissions = null)
+    {
+        parent::__construct($name, $permissions);
+
+        $this->errorMessages = $errorMessages;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function open(): void
+    {
+        if (isset($this->errorMessages['open'])) {
+            trigger_error($this->errorMessages['open'], E_USER_WARNING);
+
+            return;
+        }
+
+        parent::open();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function openForAppend(): void
+    {
+        if (isset($this->errorMessages['open'])) {
+            trigger_error($this->errorMessages['open'], E_USER_WARNING);
+
+            return;
+        }
+
+        parent::openForAppend();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function openWithTruncate(): void
+    {
+        if (isset($this->errorMessages['open'])) {
+            trigger_error($this->errorMessages['open'], E_USER_WARNING);
+
+            return;
+        }
+
+        parent::openWithTruncate();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function read(int $count): string
+    {
+        if (isset($this->errorMessages['read'])) {
+            trigger_error($this->errorMessages['read'], E_USER_WARNING);
+
+            return '';
+        }
+
+        return parent::read($count);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function readUntilEnd(): string
+    {
+        if (isset($this->errorMessages['read'])) {
+            trigger_error($this->errorMessages['read'], E_USER_WARNING);
+
+            return '';
+        }
+
+        return parent::readUntilEnd();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function write(string $data): int
+    {
+        if (isset($this->errorMessages['write'])) {
+            trigger_error($this->errorMessages['write'], E_USER_WARNING);
+
+            return 0;
+        }
+
+        return parent::write($data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function truncate(int $size): bool
+    {
+        if (isset($this->errorMessages['truncate'])) {
+            trigger_error($this->errorMessages['truncate'], E_USER_WARNING);
+
+            return false;
+        }
+
+        return parent::truncate($size);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function eof(): bool
+    {
+        if (isset($this->errorMessages['eof'])) {
+            trigger_error($this->errorMessages['eof'], E_USER_WARNING);
+
+            // True on error.
+            // See: https://www.php.net/manual/en/function.feof.php#refsect1-function.feof-returnvalues
+            return true;
+        }
+
+        return parent::eof();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBytesRead(): int
+    {
+        if (isset($this->errorMessages['tell'])) {
+            trigger_error($this->errorMessages['tell'], E_USER_WARNING);
+
+            return 0;
+        }
+
+        return parent::getBytesRead();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function seek(int $offset, int $whence): bool
+    {
+        if (isset($this->errorMessages['seek'])) {
+            trigger_error($this->errorMessages['seek'], E_USER_WARNING);
+
+            return false;
+        }
+
+        return parent::seek($offset, $whence);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function size(): int
+    {
+        if (isset($this->errorMessages['stat'])) {
+            trigger_error($this->errorMessages['stat'], E_USER_WARNING);
+
+            return 0;
+        }
+
+        return parent::size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function lock($resource, int $operation): bool
+    {
+        if (isset($this->errorMessages['lock'])) {
+            trigger_error($this->errorMessages['lock'], E_USER_WARNING);
+
+            return false;
+        }
+
+        return parent::lock($resource, $operation);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function filemtime(): int
+    {
+        if (isset($this->errorMessages['stat'])) {
+            trigger_error($this->errorMessages['stat'], E_USER_WARNING);
+
+            return 0;
+        }
+
+        return parent::filemtime();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fileatime(): int
+    {
+        if (isset($this->errorMessages['stat'])) {
+            trigger_error($this->errorMessages['stat'], E_USER_WARNING);
+
+            return 0;
+        }
+
+        return parent::fileatime();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function filectime(): int
+    {
+        if (isset($this->errorMessages['stat'])) {
+            trigger_error($this->errorMessages['stat'], E_USER_WARNING);
+
+            return 0;
+        }
+
+        return parent::filectime();
+    }
+}

--- a/src/vfsStreamWrapper.php
+++ b/src/vfsStreamWrapper.php
@@ -679,10 +679,18 @@ class vfsStreamWrapper
     /**
      * returns status of stream
      *
-     * @return  mixed[]
+     * @return int[]|false
      */
-    public function stream_stat(): array
+    public function stream_stat()
     {
+        $atime = $this->content->fileatime();
+        $ctime = $this->content->filectime();
+        $mtime = $this->content->filemtime();
+        $size = $this->content->size();
+        if ($atime === -1 || $ctime === -1 || $mtime === -1 || $size === -1) {
+            return false;
+        }
+
         $fileStat = [
             'dev' => 0,
             'ino' => spl_object_id($this->content),
@@ -691,10 +699,10 @@ class vfsStreamWrapper
             'uid' => $this->content->getUser(),
             'gid' => $this->content->getGroup(),
             'rdev' => 0,
-            'size' => $this->content->size(),
-            'atime' => $this->content->fileatime(),
-            'mtime' => $this->content->filemtime(),
-            'ctime' => $this->content->filectime(),
+            'size' => $size,
+            'atime' => $atime,
+            'mtime' => $mtime,
+            'ctime' => $ctime,
             'blksize' => -1,
             'blocks' => -1,
         ];
@@ -1035,6 +1043,14 @@ class vfsStreamWrapper
             return false;
         }
 
+        $atime = $content->fileatime();
+        $ctime = $content->filectime();
+        $mtime = $content->filemtime();
+        $size = $content->size();
+        if ($atime === -1 || $ctime === -1 || $mtime === -1 || $size === -1) {
+            return false;
+        }
+
         $fileStat = [
             'dev' => 0,
             'ino' => spl_object_id($content),
@@ -1043,10 +1059,10 @@ class vfsStreamWrapper
             'uid' => $content->getUser(),
             'gid' => $content->getGroup(),
             'rdev' => 0,
-            'size' => $content->size(),
-            'atime' => $content->fileatime(),
-            'mtime' => $content->filemtime(),
-            'ctime' => $content->filectime(),
+            'size' => $size,
+            'atime' => $atime,
+            'mtime' => $mtime,
+            'ctime' => $ctime,
             'blksize' => -1,
             'blocks' => -1,
         ];

--- a/tests/phpunit/vfsStreamErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamErroneousFileTestCase.php
@@ -13,7 +13,6 @@ namespace bovigo\vfs\tests;
 
 use bovigo\vfs\vfsStream;
 use bovigo\vfs\vfsStreamErroneousFile;
-use bovigo\vfs\vfsStreamWrapper;
 use const E_USER_WARNING;
 use function bovigo\assert\assertEmptyString;
 use function bovigo\assert\assertFalse;
@@ -228,21 +227,19 @@ class vfsStreamErroneousFileTestCase extends vfsStreamFileTestCase
 
     public function testLockWithErrorMessageTriggersError(): void
     {
-        $wrapper = $this->createMock(vfsStreamWrapper::class);
         $message = uniqid();
         $file = vfsStream::newErroneousFile('foo', ['lock' => $message]);
 
         expect(static function () use ($file): void {
-            $file->lock($wrapper, rand());
+            $file->lock($file, rand());
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
 
     public function testLockWithErrorMessageReturnsFalse(): void
     {
-        $wrapper = $this->createMock(vfsStreamWrapper::class);
         $file = vfsStream::newErroneousFile('foo', ['lock' => uniqid()]);
 
-        $actual = @$file->lock($wrapper, rand());
+        $actual = @$file->lock($file, rand());
 
         assertFalse($actual);
     }

--- a/tests/phpunit/vfsStreamErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamErroneousFileTestCase.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of vfsStream.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace bovigo\vfs\tests;
+
+use bovigo\vfs\vfsStream;
+use bovigo\vfs\vfsStreamErroneousFile;
+use bovigo\vfs\vfsStreamWrapper;
+use const E_USER_WARNING;
+use function bovigo\assert\assertEmptyString;
+use function bovigo\assert\assertFalse;
+use function bovigo\assert\assertThat;
+use function bovigo\assert\assertTrue;
+use function bovigo\assert\expect;
+use function bovigo\assert\predicate\equals;
+use function rand;
+use function uniqid;
+
+/**
+ * Test for bovigo\vfs\vfsStreamErroneousFile.
+ */
+class vfsStreamErroneousFileTestCase extends vfsStreamFileTestCase
+{
+    /**
+     * instance to test
+     *
+     * @var vfsStreamErroneousFile
+     */
+    protected $file;
+
+    /**
+     * set up test environment
+     */
+    protected function setUp(): void
+    {
+        $this->file = vfsStream::newErroneousFile('foo', []);
+    }
+
+    public function testOpenWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['open' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->open();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testOpenForAppendWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['open' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->openForAppend();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testOpenWithTruncateWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['open' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->openWithTruncate();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testReadWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['read' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->read(rand());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testReadWithErrorMessageReturnsEmptyString(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['read' => uniqid()]);
+
+        $actual = @$file->read(rand());
+
+        assertEmptyString($actual);
+    }
+
+    public function testReadUntilEndWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['read' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->readUntilEnd(rand());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testReadUntilEndWithErrorMessageReturnsEmptyString(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['read' => uniqid()]);
+
+        $actual = @$file->readUntilEnd(rand());
+
+        assertEmptyString($actual);
+    }
+
+    public function testWriteWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['write' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->write(uniqid());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testWriteWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['write' => uniqid()]);
+
+        $actual = @$file->write(uniqid());
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testTruncateWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['truncate' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->truncate(rand());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testTruncateWithErrorMessageReturnsFalse(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['truncate' => uniqid()]);
+
+        $actual = @$file->truncate(rand());
+
+        assertFalse($actual);
+    }
+
+    public function testEofWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['eof' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->eof();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testEofWithErrorMessageReturnsTrue(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['eof' => uniqid()]);
+
+        $actual = @$file->eof();
+
+        assertTrue($actual);
+    }
+
+    public function testGetBytesReadWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['tell' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->getBytesRead();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testGetBytesReadWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['tell' => uniqid()]);
+
+        $actual = @$file->getBytesRead();
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testSeekWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['seek' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->seek(rand(), rand());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testSeekWithErrorMessageReturnsFalse(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['seek' => uniqid()]);
+
+        $actual = @$file->seek(rand(), rand());
+
+        assertFalse($actual);
+    }
+
+    public function testSizeWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['stat' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->size();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testSizeWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()]);
+
+        $actual = @$file->size();
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testLockWithErrorMessageTriggersError(): void
+    {
+        $wrapper = $this->createMock(vfsStreamWrapper::class);
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['lock' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->lock($wrapper, rand());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testLockWithErrorMessageReturnsFalse(): void
+    {
+        $wrapper = $this->createMock(vfsStreamWrapper::class);
+        $file = vfsStream::newErroneousFile('foo', ['lock' => uniqid()]);
+
+        $actual = @$file->lock($wrapper, rand());
+
+        assertFalse($actual);
+    }
+
+    public function testFilemtimeWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['stat' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->filemtime();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testFilemtimeWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()]);
+
+        $actual = @$file->filemtime();
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testFileatimeWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['stat' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->fileatime();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testFileatimeWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()]);
+
+        $actual = @$file->fileatime();
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testFilectimeWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['stat' => $message]);
+
+        expect(static function () use ($file): void {
+            $file->filectime();
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testFilectimeWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()]);
+
+        $actual = @$file->filectime();
+
+        assertThat($actual, equals(0));
+    }
+}

--- a/tests/phpunit/vfsStreamErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamErroneousFileTestCase.php
@@ -216,13 +216,13 @@ class vfsStreamErroneousFileTestCase extends vfsStreamFileTestCase
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
 
-    public function testSizeWithErrorMessageReturnsZero(): void
+    public function testSizeWithErrorMessageReturnsNegativeOne(): void
     {
         $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()]);
 
         $actual = @$file->size();
 
-        assertThat($actual, equals(0));
+        assertThat($actual, equals(-1));
     }
 
     public function testLockWithErrorMessageTriggersError(): void
@@ -254,13 +254,13 @@ class vfsStreamErroneousFileTestCase extends vfsStreamFileTestCase
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
 
-    public function testFilemtimeWithErrorMessageReturnsZero(): void
+    public function testFilemtimeWithErrorMessageReturnsNegativeOne(): void
     {
         $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()]);
 
         $actual = @$file->filemtime();
 
-        assertThat($actual, equals(0));
+        assertThat($actual, equals(-1));
     }
 
     public function testFileatimeWithErrorMessageTriggersError(): void
@@ -273,13 +273,13 @@ class vfsStreamErroneousFileTestCase extends vfsStreamFileTestCase
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
 
-    public function testFileatimeWithErrorMessageReturnsZero(): void
+    public function testFileatimeWithErrorMessageReturnsNegativeOne(): void
     {
         $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()]);
 
         $actual = @$file->fileatime();
 
-        assertThat($actual, equals(0));
+        assertThat($actual, equals(-1));
     }
 
     public function testFilectimeWithErrorMessageTriggersError(): void
@@ -292,12 +292,12 @@ class vfsStreamErroneousFileTestCase extends vfsStreamFileTestCase
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
 
-    public function testFilectimeWithErrorMessageReturnsZero(): void
+    public function testFilectimeWithErrorMessageReturnsNegativeOne(): void
     {
         $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()]);
 
         $actual = @$file->filectime();
 
-        assertThat($actual, equals(0));
+        assertThat($actual, equals(-1));
     }
 }

--- a/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of vfsStream.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace bovigo\vfs\tests;
+
+use bovigo\vfs\vfsStream;
+use bovigo\vfs\vfsStreamWrapper;
+use const E_USER_WARNING;
+use const LOCK_SH;
+use const SEEK_SET;
+use function bovigo\assert\assertEmptyString;
+use function bovigo\assert\assertFalse;
+use function bovigo\assert\assertThat;
+use function bovigo\assert\assertTrue;
+use function bovigo\assert\expect;
+use function bovigo\assert\predicate\equals;
+use function fclose;
+use function feof;
+use function fileatime;
+use function filectime;
+use function filemtime;
+use function flock;
+use function fopen;
+use function fread;
+use function fseek;
+use function fstat;
+use function ftell;
+use function ftruncate;
+use function fwrite;
+use function rand;
+use function spl_object_id;
+use function uniqid;
+
+/**
+ * Test for bovigo\vfs\vfsStreamWrapper.
+ */
+class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
+{
+    /**
+     * @dataProvider sampleModes
+     */
+    public function testOpenWithErrorMessageTriggersError(string $mode): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile(uniqid(), ['open' => $message])->at($this->root);
+
+        expect(static function () use ($file, $mode): void {
+            fopen($file->url(), $mode);
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function sampleModes(): array
+    {
+        return [
+            'read' => ['r'],
+            'read+write' => ['r+'],
+            'write' => ['w'],
+            'write+read' => ['w+'],
+            'append' => ['a'],
+            'append+read' => ['a+'],
+            'create' => ['c'],
+            'create+read' => ['c+'],
+        ];
+    }
+
+    public function testReadWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['read' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            $fh = fopen($file->url(), 'r');
+            fread($fh, rand());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testReadWithErrorMessageReturnsEmptyString(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['read' => uniqid()])->at($this->root);
+
+        $fh = fopen($file->url(), 'r');
+        $actual = @fread($fh, rand());
+
+        assertEmptyString($actual);
+    }
+
+    public function testWriteWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['write' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            $fh = fopen($file->url(), 'w');
+            fwrite($fh, uniqid());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testWriteWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['write' => uniqid()])->at($this->root);
+
+        $fh = fopen($file->url(), 'w');
+        $actual = @fwrite($fh, uniqid());
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testTruncateWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['truncate' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            $fh = fopen($file->url(), 'w+');
+            ftruncate($fh, rand());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testTruncateWithErrorMessageReturnsFalse(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['truncate' => uniqid()])->at($this->root);
+
+        $fh = fopen($file->url(), 'w+');
+        $actual = @ftruncate($fh, rand());
+
+        assertFalse($actual);
+    }
+
+    public function testEofWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['eof' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            $fh = fopen($file->url(), 'w+');
+            feof($fh);
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testEofWithErrorMessageReturnsTrue(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['eof' => uniqid()])->at($this->root)->setContent(uniqid());
+
+        $fh = fopen($file->url(), 'w+');
+        $actual = @feof($fh);
+
+        assertTrue($actual);
+    }
+
+    public function testTellWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['tell' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            $fh = fopen($file->url(), 'w');
+            fseek($fh, 0, SEEK_SET);
+            ftell($fh);
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testTellWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['tell' => uniqid()])->at($this->root);
+
+        $fh = fopen($file->url(), 'w');
+        @fseek($fh, 1, SEEK_SET);
+
+        $actual = @ftell($fh);
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testSeekWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['seek' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            $fh = fopen($file->url(), 'w');
+            fseek($fh, 0, SEEK_SET);
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testSeekWithErrorMessageReturnsNegativeOne(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['seek' => uniqid()])->at($this->root);
+
+        $fh = fopen($file->url(), 'w');
+        $actual = @fseek($fh, 1, SEEK_SET);
+
+        assertThat($actual, equals(-1));
+    }
+
+    public function testStatWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['stat' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            $fh = fopen($file->url(), 'w');
+            fstat($fh);
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testStatWithErrorMessageReturnsArray(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
+
+        $fh = fopen($file->url(), 'w');
+        $actual = @fstat($fh);
+
+        assertThat(
+            $actual,
+            equals(
+                [
+                    0 => 0,
+                    1 => spl_object_id($file),
+                    2 => 0100666,
+                    3 => 0,
+                    4 => vfsStream::getCurrentUser(),
+                    5 => vfsStream::getCurrentGroup(),
+                    6 => 0,
+                    7 => 0,
+                    8 => 0,
+                    9 => 0,
+                    10 => 0,
+                    11 => -1,
+                    12 => -1,
+                    'dev' => 0,
+                    'ino' => spl_object_id($file),
+                    'mode' => 0100666,
+                    'nlink' => 0,
+                    'uid' => vfsStream::getCurrentUser(),
+                    'gid' => vfsStream::getCurrentGroup(),
+                    'rdev' => 0,
+                    'size' => 0,
+                    'atime' => 0,
+                    'mtime' => 0,
+                    'ctime' => 0,
+                    'blksize' => -1,
+                    'blocks' => -1,
+                ]
+            )
+        );
+    }
+
+    public function testLockWithErrorMessageTriggersError(): void
+    {
+        $wrapper = $this->createMock(vfsStreamWrapper::class);
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['lock' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            $fh = fopen($file->url(), 'r');
+            flock($fh, LOCK_SH);
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testLockWithErrorMessageReturnsFalse(): void
+    {
+        $wrapper = $this->createMock(vfsStreamWrapper::class);
+        $file = vfsStream::newErroneousFile('foo', ['lock' => uniqid()])->at($this->root);
+
+        $fh = @fopen($file->url(), 'r');
+        $actual = @flock($fh, LOCK_SH);
+        @fclose($fh); // Close calls lock to unlock
+
+        assertFalse($actual);
+    }
+
+    public function testFilemtimeWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['stat' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            filemtime($file->url());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testFilemtimeWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
+
+        $actual = @filemtime($file->url());
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testFileatimeWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['stat' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            fileatime($file->url());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testFileatimeWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
+
+        $actual = @fileatime($file->url());
+
+        assertThat($actual, equals(0));
+    }
+
+    public function testFilectimeWithErrorMessageTriggersError(): void
+    {
+        $message = uniqid();
+        $file = vfsStream::newErroneousFile('foo', ['stat' => $message])->at($this->root);
+
+        expect(static function () use ($file): void {
+            filectime($file->url());
+        })->triggers(E_USER_WARNING)->withMessage($message);
+    }
+
+    public function testFilectimeWithErrorMessageReturnsZero(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
+
+        $actual = @filectime($file->url());
+
+        assertThat($actual, equals(0));
+    }
+}

--- a/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace bovigo\vfs\tests;
 
 use bovigo\vfs\vfsStream;
-use bovigo\vfs\vfsStreamWrapper;
 use const E_USER_WARNING;
 use const LOCK_SH;
 use const SEEK_SET;
@@ -258,7 +257,6 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
 
     public function testLockWithErrorMessageTriggersError(): void
     {
-        $wrapper = $this->createMock(vfsStreamWrapper::class);
         $message = uniqid();
         $file = vfsStream::newErroneousFile('foo', ['lock' => $message])->at($this->root);
 
@@ -270,7 +268,6 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
 
     public function testLockWithErrorMessageReturnsFalse(): void
     {
-        $wrapper = $this->createMock(vfsStreamWrapper::class);
         $file = vfsStream::newErroneousFile('foo', ['lock' => uniqid()])->at($this->root);
 
         $fh = @fopen($file->url(), 'r');

--- a/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
@@ -36,6 +36,7 @@ use function ftruncate;
 use function fwrite;
 use function rand;
 use function spl_object_id;
+use function time;
 use function uniqid;
 
 /**
@@ -100,7 +101,7 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
         $file = vfsStream::newErroneousFile('foo', ['write' => $message])->at($this->root);
 
         expect(static function () use ($file): void {
-            $fh = fopen($file->url(), 'w');
+            $fh = fopen($file->url(), 'a');
             fwrite($fh, uniqid());
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
@@ -109,7 +110,7 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
     {
         $file = vfsStream::newErroneousFile('foo', ['write' => uniqid()])->at($this->root);
 
-        $fh = fopen($file->url(), 'w');
+        $fh = fopen($file->url(), 'a');
         $actual = @fwrite($fh, uniqid());
 
         assertThat($actual, equals(0));
@@ -296,6 +297,15 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
         assertThat($actual, equals(0));
     }
 
+    public function testFilemtimeWithoutError(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', [])->at($this->root);
+
+        $actual = filemtime($file->url());
+
+        assertThat($actual, equals(time(), 1));
+    }
+
     public function testFileatimeWithErrorMessageTriggersError(): void
     {
         $message = uniqid();
@@ -315,6 +325,15 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
         assertThat($actual, equals(0));
     }
 
+    public function testFileatimeWithoutError(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', [])->at($this->root);
+
+        $actual = fileatime($file->url());
+
+        assertThat($actual, equals(time(), 1));
+    }
+
     public function testFilectimeWithErrorMessageTriggersError(): void
     {
         $message = uniqid();
@@ -332,5 +351,14 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
         $actual = @filectime($file->url());
 
         assertThat($actual, equals(0));
+    }
+
+    public function testFilectimeWithoutError(): void
+    {
+        $file = vfsStream::newErroneousFile('foo', [])->at($this->root);
+
+        $actual = filectime($file->url());
+
+        assertThat($actual, equals(time(), 1));
     }
 }

--- a/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
@@ -13,6 +13,7 @@ namespace bovigo\vfs\tests;
 
 use bovigo\vfs\vfsStream;
 use const E_USER_WARNING;
+use const E_WARNING;
 use const LOCK_SH;
 use const SEEK_SET;
 use function bovigo\assert\assertEmptyString;
@@ -35,7 +36,6 @@ use function ftell;
 use function ftruncate;
 use function fwrite;
 use function rand;
-use function spl_object_id;
 use function time;
 use function uniqid;
 
@@ -214,46 +214,14 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
 
-    public function testStatWithErrorMessageReturnsArray(): void
+    public function testStatWithErrorMessageReturnsFalse(): void
     {
         $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
 
         $fh = fopen($file->url(), 'w');
         $actual = @fstat($fh);
 
-        assertThat(
-            $actual,
-            equals(
-                [
-                    0 => 0,
-                    1 => spl_object_id($file),
-                    2 => 0100666,
-                    3 => 0,
-                    4 => vfsStream::getCurrentUser(),
-                    5 => vfsStream::getCurrentGroup(),
-                    6 => 0,
-                    7 => 0,
-                    8 => 0,
-                    9 => 0,
-                    10 => 0,
-                    11 => -1,
-                    12 => -1,
-                    'dev' => 0,
-                    'ino' => spl_object_id($file),
-                    'mode' => 0100666,
-                    'nlink' => 0,
-                    'uid' => vfsStream::getCurrentUser(),
-                    'gid' => vfsStream::getCurrentGroup(),
-                    'rdev' => 0,
-                    'size' => 0,
-                    'atime' => 0,
-                    'mtime' => 0,
-                    'ctime' => 0,
-                    'blksize' => -1,
-                    'blocks' => -1,
-                ]
-            )
-        );
+        assertFalse($actual);
     }
 
     public function testLockWithErrorMessageTriggersError(): void
@@ -280,21 +248,20 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
 
     public function testFilemtimeWithErrorMessageTriggersError(): void
     {
-        $message = uniqid();
-        $file = vfsStream::newErroneousFile('foo', ['stat' => $message])->at($this->root);
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
 
         expect(static function () use ($file): void {
             filemtime($file->url());
-        })->triggers(E_USER_WARNING)->withMessage($message);
+        })->triggers(E_WARNING)->withMessage('filemtime(): stat failed for ' . $file->url());
     }
 
-    public function testFilemtimeWithErrorMessageReturnsZero(): void
+    public function testFilemtimeWithErrorMessageReturnsFalse(): void
     {
         $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
 
         $actual = @filemtime($file->url());
 
-        assertThat($actual, equals(0));
+        assertFalse($actual);
     }
 
     public function testFilemtimeWithoutError(): void
@@ -308,21 +275,20 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
 
     public function testFileatimeWithErrorMessageTriggersError(): void
     {
-        $message = uniqid();
-        $file = vfsStream::newErroneousFile('foo', ['stat' => $message])->at($this->root);
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
 
         expect(static function () use ($file): void {
             fileatime($file->url());
-        })->triggers(E_USER_WARNING)->withMessage($message);
+        })->triggers(E_WARNING)->withMessage('fileatime(): stat failed for ' . $file->url());
     }
 
-    public function testFileatimeWithErrorMessageReturnsZero(): void
+    public function testFileatimeWithErrorMessageReturnsFalse(): void
     {
         $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
 
         $actual = @fileatime($file->url());
 
-        assertThat($actual, equals(0));
+        assertFalse($actual);
     }
 
     public function testFileatimeWithoutError(): void
@@ -336,21 +302,20 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
 
     public function testFilectimeWithErrorMessageTriggersError(): void
     {
-        $message = uniqid();
-        $file = vfsStream::newErroneousFile('foo', ['stat' => $message])->at($this->root);
+        $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
 
         expect(static function () use ($file): void {
             filectime($file->url());
-        })->triggers(E_USER_WARNING)->withMessage($message);
+        })->triggers(E_WARNING)->withMessage('filectime(): stat failed for ' . $file->url());
     }
 
-    public function testFilectimeWithErrorMessageReturnsZero(): void
+    public function testFilectimeWithErrorMessageReturnsFalse(): void
     {
         $file = vfsStream::newErroneousFile('foo', ['stat' => uniqid()])->at($this->root);
 
         $actual = @filectime($file->url());
 
-        assertThat($actual, equals(0));
+        assertFalse($actual);
     }
 
     public function testFilectimeWithoutError(): void


### PR DESCRIPTION
This allows for setting up error messages for basic file actions, such as: open, read, write, truncate, tell, seek, stat, eof, and lock.

Example:

```php
$root = vfsStream::setup();
$file = vfsStream::newErronousFile('foo.txt', ['open' => 'error message'])->at($root);

fopen($file->url(), 'w');
// error message
```

Closes #155