### PR TITLE
Limit maximum amount of bytes to read, fixes #216

### DIFF
--- a/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
@@ -73,6 +73,7 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
             'create+read' => ['c+'],
         ];
     }
+
     public function testReadWithErrorMessageTriggersError(): void
     {
         $message = uniqid();

--- a/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
+++ b/tests/phpunit/vfsStreamWrapperErroneousFileTestCase.php
@@ -73,7 +73,6 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
             'create+read' => ['c+'],
         ];
     }
-
     public function testReadWithErrorMessageTriggersError(): void
     {
         $message = uniqid();
@@ -81,7 +80,7 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
 
         expect(static function () use ($file): void {
             $fh = fopen($file->url(), 'r');
-            fread($fh, rand());
+            fread($fh, rand(1, 10000));
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
 
@@ -90,7 +89,7 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
         $file = vfsStream::newErroneousFile('foo', ['read' => uniqid()])->at($this->root);
 
         $fh = fopen($file->url(), 'r');
-        $actual = @fread($fh, rand());
+        $actual = @fread($fh, rand(1, 10000));
 
         assertEmptyString($actual);
     }
@@ -123,7 +122,7 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
 
         expect(static function () use ($file): void {
             $fh = fopen($file->url(), 'w+');
-            ftruncate($fh, rand());
+            ftruncate($fh, rand(1, 10000));
         })->triggers(E_USER_WARNING)->withMessage($message);
     }
 
@@ -132,7 +131,7 @@ class vfsStreamWrapperErroneousFileTestCase extends vfsStreamWrapperBaseTestCase
         $file = vfsStream::newErroneousFile('foo', ['truncate' => uniqid()])->at($this->root);
 
         $fh = fopen($file->url(), 'w+');
-        $actual = @ftruncate($fh, rand());
+        $actual = @ftruncate($fh, rand(1, 10000));
 
         assertFalse($actual);
     }


### PR DESCRIPTION
The result of `rand()` can be numbers of up to 2147483647 (PHP 7.3.14 on macOS). Before the actual file read PHP allocates the amount of memory specified by the second argument to `fread()` to ensure everything fits into memory. For unit tests that's bad, as it can mean allocating 2 GB of memory.

Therefore this fix limits the amount to 10000. For typical vfsStream usages that's more than sufficient. The usage of `rand()` is kept to verify that the functionality tested works independent of the amount of bytes to be read from the file.