### PR TITLE
Add missing return type/value

### DIFF
--- a/src/vfsStreamWrapper.php
+++ b/src/vfsStreamWrapper.php
@@ -1008,9 +1008,11 @@ class vfsStreamWrapper
     /**
      * reset directory iteration
      */
-    public function dir_rewinddir(): void
+    public function dir_rewinddir(): bool
     {
         $this->dirIterator->rewind();
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Quick PR to make `dir_rewinddir` follow what [the docs](https://www.php.net/manual/en/streamwrapper.dir-rewinddir.php) say the return value should be

Closes #202