### PR TITLE
 Fix for Issue #222: handle EOF and offset correctly on read 

### DIFF
--- a/src/OpenedFile.php
+++ b/src/OpenedFile.php
@@ -261,7 +261,7 @@ final class OpenedFile
 
     private function restorePosition(): void
     {
-        $this->base->getContentObject()->seek($this->position, SEEK_SET);
+        $this->base->getContentObject()->seek($this->position, SEEK_SET, false);
     }
 
     private function savePosition(): void

--- a/src/content/FileContent.php
+++ b/src/content/FileContent.php
@@ -38,7 +38,7 @@ interface FileContent
     /**
      * seeks to the given offset
      */
-    public function seek(int $offset, int $whence): bool;
+    public function seek(int $offset, int $whence, bool $resetEof = true): bool;
 
     /**
      * checks whether pointer is at end of file

--- a/tests/phpunit/content/StringBasedFileContentTestCase.php
+++ b/tests/phpunit/content/StringBasedFileContentTestCase.php
@@ -125,18 +125,38 @@ class StringBasedFileContentTestCase extends TestCase
     /**
      * @test
      */
-    public function readSizeReachesEof(): void
+    public function readSizeReachesDoesNotReachEof(): void
     {
         $this->stringBasedFileContent->read(9);
+        assertFalse($this->stringBasedFileContent->eof());
+    }
+
+    /**
+     * @test
+     */
+    public function readSizeReachesEofOnNextRead(): void
+    {
+        $this->stringBasedFileContent->read(9);
+        $this->stringBasedFileContent->read(1);
         assertTrue($this->stringBasedFileContent->eof());
     }
 
     /**
      * @test
      */
-    public function readMoreThanSizeReachesEof(): void
+    public function readMoreThanSizeDoesNotReachEof(): void
     {
         $this->stringBasedFileContent->read(10);
+        assertFalse($this->stringBasedFileContent->eof());
+    }
+
+    /**
+     * @test
+     */
+    public function readMoreThanSizeReachesEofOnNextRead(): void
+    {
+        $this->stringBasedFileContent->read(10);
+        $this->stringBasedFileContent->read(1);
         assertTrue($this->stringBasedFileContent->eof());
     }
 

--- a/tests/phpunit/vfsStreamFileTestCase.php
+++ b/tests/phpunit/vfsStreamFileTestCase.php
@@ -145,9 +145,9 @@ class vfsStreamFileTestCase extends TestCase
     /**
      * @test
      */
-    public function isAtEofWhenEmpty(): void
+    public function isNotAtEofWhenEmpty(): void
     {
-        assertTrue($this->file->eof());
+        assertFalse($this->file->eof());
     }
 
     /**
@@ -169,19 +169,10 @@ class vfsStreamFileTestCase extends TestCase
     /**
      * @test
      */
-    public function readFromEmptyFileMovesPointer(): void
+    public function readFromEmptyFileDoesNotMovePointer(): void
     {
         $this->file->read(5);
-        assertThat($this->file->getBytesRead(), equals(5));
-    }
-
-    /**
-     * @test
-     */
-    public function reportsAmountOfBytesReadEvenWhenEmpty(): void
-    {
-        $this->file->read(5);
-        assertThat($this->file->getBytesRead(), equals(5));
+        assertThat($this->file->getBytesRead(), equals(0));
     }
 
     /**
@@ -227,6 +218,10 @@ class vfsStreamFileTestCase extends TestCase
         assertFalse($this->file->eof());
 
         assertThat($this->file->read(3), equals('baz'));
+        assertThat($this->file->getBytesRead(), equals(9));
+        assertFalse($this->file->eof());
+
+        assertThat($this->file->read(1), equals(''));
         assertThat($this->file->getBytesRead(), equals(9));
         assertTrue($this->file->eof());
     }

--- a/tests/phpunit/vfsStreamWrapperFileTestCase.php
+++ b/tests/phpunit/vfsStreamWrapperFileTestCase.php
@@ -172,6 +172,7 @@ class vfsStreamWrapperFileTestCase extends vfsStreamWrapperBaseTestCase
     {
         $fp = fopen($this->fileInSubdir->url(), 'r');
         fseek($fp, 1, SEEK_END);
+        fread($fp, 1);
         assertTrue(feof($fp));
         fclose($fp);
     }

--- a/tests/phpunit/vfsStreamWrapperTestCase.php
+++ b/tests/phpunit/vfsStreamWrapperTestCase.php
@@ -904,4 +904,98 @@ class vfsStreamWrapperTestCase extends vfsStreamWrapperBaseTestCase
 
         assertThat(file_get_contents($url), equals($contentB . $contentA));
     }
+
+    /**
+     * @test
+     */
+    public function readsAndWritesOnSameFileHaveDifferentPointers(): void
+    {
+        $contentA = uniqid('a');
+        $contentB = uniqid('b');
+        $url = $this->fileInSubdir->url();
+
+        $fp1 = fopen($url, 'wb');
+        $fp2 = fopen($url, 'rb');
+
+        fwrite($fp1, $contentA);
+        $contentBeforeWrite = fread($fp2, strlen($contentA));
+
+        fwrite($fp1, $contentB);
+        $contentAfterWrite = fread($fp2, strlen($contentB));
+
+        fclose($fp1);
+        fclose($fp2);
+
+        assertThat($contentBeforeWrite, equals($contentA));
+        assertThat($contentAfterWrite, equals($contentB));
+    }
+
+    /**
+     * @test
+     */
+    public function feofIsFalseWhenEmptyFileOpened(): void
+    {
+        $this->fileInSubdir->setContent('');
+
+        $stream = fopen($this->fileInSubdir->url(), 'r');
+
+        assertFalse(feof($stream));
+    }
+
+    /**
+     * @test
+     */
+    public function feofIsTrueAfterEmptyFileRead(): void
+    {
+        $this->fileInSubdir->setContent('');
+
+        $stream = fopen($this->fileInSubdir->url(), 'r');
+
+        fgets($stream);
+
+        assertTrue(feof($stream));
+    }
+
+    /**
+     * @test
+     */
+    public function feofIsFalseWhenEmptyStreamRewound(): void
+    {
+        $this->fileInSubdir->setContent('');
+
+        $stream = fopen($this->fileInSubdir->url(), 'r');
+
+        fgets($stream);
+        rewind($stream);
+        assertFalse(feof($stream));
+    }
+
+    /**
+     * @test
+     */
+    public function feofIsFalseAfterReadingLastLine(): void
+    {
+        $this->fileInSubdir->setContent("Line 1\n");
+
+        $stream = fopen($this->fileInSubdir->url(), 'r');
+
+        fgets($stream);
+
+        assertFalse(feof($stream));
+    }
+
+    /**
+     * @test
+     */
+    public function feofIsTrueAfterReadingBeyondLastLine(): void
+    {
+        $this->fileInSubdir->setContent("Line 1\n");
+
+        $stream = fopen($this->fileInSubdir->url(), 'r');
+
+        fgets($stream);
+        fgets($stream);
+
+        assertTrue(feof($stream));
+    }
 }


### PR DESCRIPTION
The EOF flag on native file streams is only set after reading *past* the end of the stream, never on open or seek. Similarly, `fread` will never push the file position past the current end of the stream.

I have changed various tests which I believe were asserting behaviour that doesn't match the native implementation.