### PR TITLE
Add annotations to indicate return type will change for PHP 8.1 compatibility

### DIFF
--- a/src/DotDirectory.php
+++ b/src/DotDirectory.php
@@ -24,6 +24,7 @@ class DotDirectory extends vfsDirectory
      *
      * @return  vfsDirectoryIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator(array());

--- a/src/vfsDirectory.php
+++ b/src/vfsDirectory.php
@@ -255,6 +255,7 @@ class vfsDirectory extends BasicFile implements vfsStreamContainer
      *
      * @return  vfsDirectoryIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new vfsDirectoryIterator($this->children);

--- a/src/vfsDirectoryIterator.php
+++ b/src/vfsDirectoryIterator.php
@@ -47,6 +47,7 @@ class vfsDirectoryIterator implements \Iterator
     /**
      * resets children pointer
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->children);
@@ -57,6 +58,7 @@ class vfsDirectoryIterator implements \Iterator
      *
      * @return  vfsStreamContent
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $child = current($this->children);
@@ -72,6 +74,7 @@ class vfsDirectoryIterator implements \Iterator
      *
      * @return  string
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $child = current($this->children);
@@ -85,6 +88,7 @@ class vfsDirectoryIterator implements \Iterator
     /**
      * iterates to next child
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->children);
@@ -95,6 +99,7 @@ class vfsDirectoryIterator implements \Iterator
      *
      * @return  bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return (false !== current($this->children));


### PR DESCRIPTION
For v1.x - master branch already has return type hints.