### PR TITLE
Add 5.3 - 5.5 testing back to CI

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - v1.6
-      - 1-6-10-testing
   pull_request:
     branches:
       - v1.6

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - v1.6
+      - 1-6-10-testing
   pull_request:
     branches:
       - v1.6

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -16,6 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         php-versions:
+          - '5.3'
+          - '5.4'
+          - '5.5'
           - '5.6'
           - '7.0'
           - '7.1'

--- a/src/test/bootstrap.php
+++ b/src/test/bootstrap.php
@@ -40,6 +40,15 @@ if (!class_exists("PHPUnit_TextUI_ResultPrinter"))
  * (PHPUnit 4 and 5).
  */
 class BC_PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase {
+    public function bc_expectException($exception)
+    {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exception);
+        } elseif (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException($exception);
+        }
+    }
+
     // A BC hack to get handle the deprecation of this method in PHPUnit
     public function bc_getMock($originalClassName, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = false, $callOriginalMethods = false, $proxyTarget = null)
     {

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperStreamSelectTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperStreamSelectTestCase.php
@@ -23,11 +23,11 @@ class vfsStreamWrapperSelectStreamTestCase extends \BC_PHPUnit_Framework_TestCas
     {
         if (PHP_VERSION_ID >= 80000)
         {
-            $this->expectException('\ValueError');
+            $this->bc_expectException('\ValueError');
         }
         else
         {
-            $this->expectException('\PHPUnit_Framework_Error');
+            $this->bc_expectException('\PHPUnit_Framework_Error');
         }
 
         $root = vfsStream::setup();

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperStreamSelectTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperStreamSelectTestCase.php
@@ -23,11 +23,11 @@ class vfsStreamWrapperSelectStreamTestCase extends \BC_PHPUnit_Framework_TestCas
     {
         if (PHP_VERSION_ID >= 80000)
         {
-            $this->expectException(\ValueError::class);
+            $this->expectException('\ValueError');
         }
         else
         {
-            $this->expectException(\PHPUnit_Framework_Error::class);
+            $this->expectException('\PHPUnit_Framework_Error');
         }
 
         $root = vfsStream::setup();


### PR DESCRIPTION
Since the 1.6.x series supports >=5.3. We should probably add those versions back. But maintaining them won't be a high priority.