### PR TITLE
Add context property

### DIFF
--- a/src/vfsStreamWrapper.php
+++ b/src/vfsStreamWrapper.php
@@ -87,6 +87,12 @@ class vfsStreamWrapper
      */
     public const ALL = 2;
     /**
+     * The current context or null if none passed.
+     *
+     * @var resource|null
+     */
+    public $context;
+    /**
      * switch whether class has already been registered as stream wrapper or not
      *
      * @var  bool

--- a/tests/phpt/bug71287.phpt
+++ b/tests/phpt/bug71287.phpt
@@ -6,6 +6,12 @@ See https://github.com/mikey179/vfsStream/issues/120
 --FILE--
 <?php
 class Stream {
+    /**
+     * The current context or null if none passed.
+     *
+     * @var resource|null
+     */
+    public $context;
     public function stream_open($path, $mode, $options, $opened_path) {
 
         return true;


### PR DESCRIPTION
Streams are expected to have a context property to be populated with the
current context. Starting with PHP 8.2, not including this property with emit a
deprecation warning.