### PR TITLE
Correct stream wrapper property name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,10 @@
     - `org\bovigo\vfs\content\SeekableFileContent`
   * raised requirement for minimum PHP version to 5.6.0
 
-1.6.11 (2022-??-??)
+1.6.11 (2022-07-26)
 -------------------
 
-  * Add support for PHP 8.2's `$content` property in `vfsStreamWrapper`
+  * Add support for PHP 8.2's `$context` property in `vfsStreamWrapper`
 
 1.6.10 (2021-09-25)
 -------------------


### PR DESCRIPTION
The property is `context` not `content`

https://www.php.net/manual/en/class.streamwrapper.php#streamwrapper.props.context

It is correct in the code. Correct it in the changelog, and put the actual release date of 1.6.11 into the changelog.