### PR TITLE
ci: Add config section for allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,10 @@
     "scripts": {
         "test": "phpunit",
         "php-coveralls": "php-coveralls"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
This will hopefully fix the ci

```
Error: dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
```